### PR TITLE
stable-PC

### DIFF
--- a/pcalg.py
+++ b/pcalg.py
@@ -46,12 +46,22 @@ def estimate_skeleton(indep_test_func, data_matrix, alpha, **kwargs):
         kwargs:
             'max_reach': maximum value of l (see the code).  The
                 value depends on the underlying distribution.
+            'method': if 'stable' given, use stable-PC algorithm
+                (see [Colombo2014]).
             other parameters may be passed depending on the
                 indep_test_func()s.
     Returns:
         g: a skeleton graph (as a networkx.Graph).
         sep_set: a separation set (as an 2D-array of set()).
+
+    [Colombo2014] Diego Colombo and Marloes H Maathuis. Order-independent
+    constraint-based causal structure learning. In The Journal of Machine
+    Learning Research, Vol. 15, pp. 3741-3782, 2014.
     """
+
+    def method_stable(kwargs):
+        return ('method' in kwargs) and kwargs['method'] == "stable"
+
     node_ids = range(data_matrix.shape[1])
     g = _create_complete_graph(node_ids)
 
@@ -63,11 +73,9 @@ def estimate_skeleton(indep_test_func, data_matrix, alpha, **kwargs):
         cont = False
         for (i, j) in permutations(node_ids, 2):
             adj_i = g.neighbors(i)
-            if j not in adj_i:
+            if j not in adj_i and not method_stable(kwargs):
                 continue
-            else:
-                adj_i.remove(j)
-                pass
+            adj_i.remove(j)
             if len(adj_i) >= l:
                 _logger.debug('testing %s and %s' % (i,j))
                 _logger.debug('neighbors of %s are %s' % (i, str(adj_i)))
@@ -99,6 +107,7 @@ def estimate_skeleton(indep_test_func, data_matrix, alpha, **kwargs):
         pass
 
     return (g, sep_set)
+
 
 def estimate_cpdag(skel_graph, sep_set):
     """Estimate a CPDAG from the skeleton graph and separation sets

--- a/pcalg.py
+++ b/pcalg.py
@@ -48,7 +48,6 @@ def estimate_skeleton(indep_test_func, data_matrix, alpha, **kwargs):
                 value depends on the underlying distribution.
             'method': if 'stable' given, use stable-PC algorithm
                 (see [Colombo2014]).
-            'verbose': for debugging
             other parameters may be passed depending on the
                 indep_test_func()s.
     Returns:
@@ -79,6 +78,7 @@ def estimate_skeleton(indep_test_func, data_matrix, alpha, **kwargs):
                 continue
             else:
                 adj_i.remove(j)
+                pass
             if len(adj_i) >= l:
                 _logger.debug('testing %s and %s' % (i,j))
                 _logger.debug('neighbors of %s are %s' % (i, str(adj_i)))
@@ -90,8 +90,6 @@ def estimate_skeleton(indep_test_func, data_matrix, alpha, **kwargs):
                     p_val = indep_test_func(data_matrix, i, j, set(k),
                                             **kwargs)
                     _logger.debug('p_val is %s' % str(p_val))
-                    print ("x= {0} y={1} S= {2}: pval= {3}".format(
-                            i, j, str(k), p_val))
                     if p_val > alpha:
                         if g.has_edge(i, j):
                             _logger.debug('p: remove edge (%s, %s)' % (i, j))

--- a/pcalg.py
+++ b/pcalg.py
@@ -48,6 +48,7 @@ def estimate_skeleton(indep_test_func, data_matrix, alpha, **kwargs):
                 value depends on the underlying distribution.
             'method': if 'stable' given, use stable-PC algorithm
                 (see [Colombo2014]).
+            'verbose': for debugging
             other parameters may be passed depending on the
                 indep_test_func()s.
     Returns:
@@ -61,6 +62,9 @@ def estimate_skeleton(indep_test_func, data_matrix, alpha, **kwargs):
 
     def method_stable(kwargs):
         return ('method' in kwargs) and kwargs['method'] == "stable"
+
+    def arg_verbose(kwargs):
+        return ('method' in kwargs) and kwargs['method'] == True
 
     node_ids = range(data_matrix.shape[1])
     g = _create_complete_graph(node_ids)
@@ -91,6 +95,9 @@ def estimate_skeleton(indep_test_func, data_matrix, alpha, **kwargs):
                     p_val = indep_test_func(data_matrix, i, j, set(k),
                                             **kwargs)
                     _logger.debug('p_val is %s' % str(p_val))
+                    if arg_verbose(kwargs):
+                        print ("x= {0} y={1} S= {2}: pval= {3}".format(
+                                i, j, str(k), p_val))
                     if p_val > alpha:
                         if g.has_edge(i, j):
                             _logger.debug('p: remove edge (%s, %s)' % (i, j))

--- a/pcalg.py
+++ b/pcalg.py
@@ -116,7 +116,6 @@ def estimate_skeleton(indep_test_func, data_matrix, alpha, **kwargs):
 
     return (g, sep_set)
 
-
 def estimate_cpdag(skel_graph, sep_set):
     """Estimate a CPDAG from the skeleton graph and separation sets
     returned by the estimate_skeleton() function.

--- a/pcalg.py
+++ b/pcalg.py
@@ -73,9 +73,13 @@ def estimate_skeleton(indep_test_func, data_matrix, alpha, **kwargs):
         cont = False
         for (i, j) in permutations(node_ids, 2):
             adj_i = g.neighbors(i)
-            if j not in adj_i and not method_stable(kwargs):
-                continue
-            adj_i.remove(j)
+            if j not in adj_i:
+                if method_stable(kwargs):
+                    pass
+                else:
+                    continue
+            else:
+                adj_i.remove(j)
             if len(adj_i) >= l:
                 _logger.debug('testing %s and %s' % (i,j))
                 _logger.debug('neighbors of %s are %s' % (i, str(adj_i)))


### PR DESCRIPTION
Original pcalg (not in R) seems to work as "original-PC".
However, original-PC is order-dependent of input nodes.
I propose to add "stable-PC" for this package.

I confirm that "stable" results of this change are consistent
with that of R-package pcalg in some datasets.

Thanks.