### PR TITLE
Bug fix for #5

### DIFF
--- a/pcalg.py
+++ b/pcalg.py
@@ -66,19 +66,22 @@ def estimate_skeleton(indep_test_func, data_matrix, alpha, **kwargs):
         return ('method' in kwargs) and kwargs['method'] == "stable"
 
     node_ids = range(data_matrix.shape[1])
+    node_size = data_matrix.shape[1]
+    sep_set = [[set() for i in range(node_size)] for j in range(node_size)]
     if 'init_graph' in kwargs:
         g = kwargs['init_graph']
         if not isinstance(g, nx.Graph):
             raise ValueError
         elif not g.number_of_nodes() == len(node_ids):
             raise ValueError('init_graph not matching data_matrix shape')
+        for (i, j) in combinations(node_ids, 2):
+            if not g.has_edge(i, j):
+                sep_set[i][j] = None
+                sep_set[j][i] = None
         pass
     else:
         g = _create_complete_graph(node_ids)
     pass
-
-    node_size = data_matrix.shape[1]
-    sep_set = [[set() for i in range(node_size)] for j in range(node_size)]
 
     l = 0
     while True:
@@ -149,6 +152,8 @@ def estimate_cpdag(skel_graph, sep_set):
             continue
         adj_j = set(dag.successors(j))
         if i in adj_j:
+            continue
+        if sep_set[i][j] is None:
             continue
         common_k = adj_i & adj_j
         for k in common_k:


### PR DESCRIPTION
Past pull request #5 has a bug in estimate_cpdag() V-structure step.

When an edge i-j is pruned by init_graph option in estimate_skeleton(), the sep_set[i][j] is left as an empty set.
In this case, the condition of V-structure "if k not in sep_set[i][j]" is satisfied.
This can cause inappropriate edge direction determination, because the actual sep_set[i][j] is unknown.
This behavior does not follow the idea of V-structure.

This pull request will remove (i, j) from the candidate of V-structure step when (i,j) is pruned by init_graph option.
I confirm the results with init_graph option before and after this pull request in some datasets, and I find this will make a small changes in the results.

Thank you.