### PR TITLE
Fix issue in Meek rule application

### DIFF
--- a/pcalg.py
+++ b/pcalg.py
@@ -190,7 +190,7 @@ def estimate_cpdag(skel_graph, sep_set):
     # rules.
     old_dag = dag.copy()
     while True:
-        for (i, j) in combinations(node_ids, 2):
+        for (i, j) in permutations(node_ids, 2):
             # Rule 1: Orient i-j into i->j whenever there is an arrow k->i
             # such that k and j are nonadjacent.
             #


### PR DESCRIPTION
This pull request fixes an issue with the application of Meek rules.

## Nature of the issue

The current code relies on the `combinations` function to generate pairs of `i, j` to consider in the loop: https://github.com/keiichishima/pcalg/blob/87165acdc7a5834975802126accafc1bd1d46c7e/pcalg.py#L193

The issue is that `combinations` considers only pairs (i, j) such that i < j. This leaves all the other pairs unchecked and thus many edges unoriented.

Example:
```
In [3]: list(combinations(range(3), 2))
Out[3]: [(0, 1), (0, 2), (1, 2)]

In [4]: list(permutations(range(3), 2))
Out[4]: [(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]
```

## Solution

The fix is easy, simply replace `combinations` by `permutations`, which will consider all pairs (i, j) with i != j.


## Example

Here is a screenshot of a graph where the issue occurred (disregard colors). You can see that the `x11 - x13 - x6` edge should've been oriented by R1, but it is not. Applying the proposed modification solves the issue and orients the edge.
![image](https://user-images.githubusercontent.com/2374980/136311416-c176c1e5-1d2d-42ce-b8af-c9d664b218e0.png)
